### PR TITLE
Write colors to config file and source it via dbus.

### DIFF
--- a/readme.org
+++ b/readme.org
@@ -10,5 +10,4 @@ The left two windows are pdf documents open in zathura.
 
 ** Installation:
 
-Clone this repository and run ~package-install-file~ on ~zathura-sync-theme.el~. Ensure that recolor is set in Zathura. Enable ~zathura-sync-theme-mode~ and you're good to go. I'm hoping to get this on Melpa soon.
-
+Clone this repository and run ~package-install-file~ on ~zathura-sync-theme.el~. Enable ~zathura-sync-theme-mode~. It will write theme colors to =zathura-theme-config= (defaults to =~/.config/zathura/theme=). Make sure you include this file in =zathurarc=. When a new theme gets enabled, the =theme= file would be overwritten and =zathura= processes would be instructed to reload config over D-Bus. I'm hoping to get this on Melpa soon.

--- a/zathura-sync-theme.el
+++ b/zathura-sync-theme.el
@@ -32,14 +32,16 @@
 (defun zathura-sync-theme--write-config ()
   "Overwrites theme config."
   (with-temp-file zathura-sync-theme-config-file
-    (insert "# synced with emacs theme by zathura-sync-theme"
-            "\nset recolor-darkcolor \\" (face-attribute 'default :foreground)
-            "\nset recolor-lightcolor \\" (face-attribute 'default :background)
-            "\nset default-fg \\" (face-attribute 'default :foreground)
-            "\nset default-bg \\" (face-attribute 'default :background)
-            "\nset statusbar-bg \\" (face-attribute 'default :background nil 'default)
-            "\nset statusbar-fg \\" (face-attribute 'default :foreground nil 'default)
-            "\nset recolor true")))
+    (let ((fg (face-attribute 'default :foreground nil 'default))
+          (bg (face-attribute 'default :background nil 'default)))
+      (insert "# synced with emacs theme by zathura-sync-theme"
+              "\nset recolor-darkcolor \\" fg
+              "\nset recolor-lightcolor \\" bg
+              "\nset default-fg \\" fg
+              "\nset default-bg \\" bg
+              "\nset statusbar-bg \\" bg
+              "\nset statusbar-fg \\" fg
+              "\nset recolor true"))))
 
 (defun zathura-sync-theme--set (&rest _args)
   "Writes theme config and sends Zathura D-Bus command to refresh it."


### PR DESCRIPTION
I use [circadian](https://github.com/guidoschmidt/circadian.el) to switch themes and it does that twice per day. As I don't have =zathura= open all the time, the colors are not applied to new instances. I've rewrote the package to write theme colors to config file and let =zathura= know when to refresh it.