### PR TITLE
Provide zathura-sync-theme

### DIFF
--- a/zathura-sync-theme.el
+++ b/zathura-sync-theme.el
@@ -19,6 +19,7 @@
 (require 'dbus)
 
 (defun zathura-set (&rest _args)
+  "Set colors in Zathura.  `_ARGS' is ignored."
   (let ((zathura-services (cl-remove-if-not (lambda (x) (cl-search "zathura" x))
 					    (dbus-list-names :session)))
 	(zathura-path "/org/pwmt/zathura")
@@ -68,7 +69,7 @@
 
 ;;;###autoload
 (define-minor-mode zathura-sync-theme-mode
-  "Synchronize the look and feel of Zathura with Emacs"
+  "Synchronize the look and feel of Zathura with Emacs."
   :global t
   :init-value nil
   :lighter "Zathura"

--- a/zathura-sync-theme.el
+++ b/zathura-sync-theme.el
@@ -1,4 +1,4 @@
-;;; zathura-sync-theme.el --- Synchronize Zathura's look and feel with Emacs 
+;;; zathura-sync-theme.el --- Synchronize Zathura's look and feel with Emacs  -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2024 Amol Vaidya
 

--- a/zathura-sync-theme.el
+++ b/zathura-sync-theme.el
@@ -13,6 +13,8 @@
 ;; https://blog.akaisuisei.org/communicating-with-zathura-via-dbus.html
 ;; written by mafty.
 
+;;; Code:
+
 (require 'cl-lib)
 
 (defun zathura-set (&rest _args)

--- a/zathura-sync-theme.el
+++ b/zathura-sync-theme.el
@@ -18,6 +18,11 @@
 (require 'cl-lib)
 (require 'dbus)
 
+(defgroup zathura-sync-theme nil
+  "Synchronize Zathura's look and feel with Emacs."
+  :prefix "zathura-"
+  :group 'applications)
+
 (defun zathura-set (&rest _args)
   "Set colors in Zathura.  `_ARGS' is ignored."
   (let ((zathura-services (cl-remove-if-not (lambda (x) (cl-search "zathura" x))

--- a/zathura-sync-theme.el
+++ b/zathura-sync-theme.el
@@ -75,4 +75,5 @@
       (advice-add 'enable-theme :after #'zathura-set)
     (advice-remove 'enable-theme #'zathura-set)))
 
+(provide 'zathura-sync-theme)
 ;;; zathura-sync-theme.el ends here

--- a/zathura-sync-theme.el
+++ b/zathura-sync-theme.el
@@ -16,6 +16,7 @@
 ;;; Code:
 
 (require 'cl-lib)
+(require 'dbus)
 
 (defun zathura-set (&rest _args)
   (let ((zathura-services (cl-remove-if-not (lambda (x) (cl-search "zathura" x))

--- a/zathura-sync-theme.el
+++ b/zathura-sync-theme.el
@@ -2,7 +2,7 @@
 
 ;; Copyright (C) 2024 Amol Vaidya
 
-;; Author: Amol Vaidya  
+;; Author: Amol Vaidya
 ;; Version: 20240608.1444
 ;; Keywords: zathura, theming
 ;; URL: https://github.com/amolv06/zathura-sync-theme


### PR DESCRIPTION
These change nothing functionally, except for making sure
```emacs-lisp
(eval-after-load 'zathura-sync-theme
   ...)
```
works as expected. I need this for the deferring logic in `use-package` to work as intended.

If you disagree with the other stylistic changes I made, I can make a smaller PR without them.